### PR TITLE
Use $http_host instead of $host for X-Forward-Host and Host

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -38,8 +38,8 @@ http {
         proxy_set_header           X-Forwarded-For  $proxy_add_x_forwarded_for;
         proxy_set_header           X-Forwarded-Proto  $scheme;
         proxy_set_header           X-Forwarded-Server  $host;
-        proxy_set_header           X-Forwarded-Host  $host;
-        proxy_set_header           Host  $host;
+        proxy_set_header           X-Forwarded-Host  $http_host;
+        proxy_set_header           Host  $http_host;
 
         client_max_body_size       10m;
         client_body_buffer_size    128k;


### PR DESCRIPTION
This retains an eventual port number in these headers.

Fixes #12
